### PR TITLE
fix: Broken routing w/ prerender

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "preact build --no-prerender",
+    "build": "preact build",
     "serve": "sirv build --port 8080 --cors --single",
     "dev": "preact watch",
     "lint": "eslint src"

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,11 @@ import './style';
 
 export default function App() {
     return (
-        <Router>
-            <Paste path="/:uuid" />
-            <Home path="/" default />
-        </Router>
+        <div id="app">
+            <Router>
+                <Home path="/" />
+                <Paste path="/:uuid" />
+            </Router>
+        </div>
     );
 }


### PR DESCRIPTION
`preact-cli` uses a mutative hydration client-side when used with prerendering on the server. This means that when the content generated on the client differs from your prerendered content, it will try to merge them. As there was no common ancestor, it cannot merge in the way you desire (one or the other). You get both, causing your issue.